### PR TITLE
update to ordered posts matching 'prepurchasing'

### DIFF
--- a/documentation/index.html
+++ b/documentation/index.html
@@ -56,7 +56,8 @@ title: CRU - Guides
                     {% endfor %}
                 </div>
                 <div role="tabpanel" class="tab-pane" id="purchasing">
-                    {% for post in site.categories.purchasing %}
+                    {% assign orderedPosts = site.categories.prepurchasing | sort: "title" %}
+                    {% for post in orderedPosts %}
                     <div class="feed-item">
 
                         <h2 class="feed-title">


### PR DESCRIPTION
@cszhu This should make it so the new docs are visible when you click on the purchasing tab.